### PR TITLE
Handle bundled packages before charm build in release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,9 @@ jobs:
 
   release:
     needs: check
-    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@v2
+    uses: canonical/bootstack-actions/.github/workflows/charm-release.yaml@v3
     secrets: inherit
     with:
       channel: "latest/edge"
       upload-image: false
+      build-preconfiguration: "make bundled-packages-update"


### PR DESCRIPTION
Depends on: https://github.com/canonical/bootstack-actions/pull/49
Closes: #7 