### PR TITLE
fix installing the python-host during build

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,7 +1,16 @@
 type: charm
 
 parts:
+  python-hosts:
+    plugin: nil
+    build-packages:
+      - pip
+    override-prime: |
+      pip install --target bundled_packages/ --upgrade python-hosts
+
   charm:
+    after:
+      - python-hosts
     plugin: dump
     source: .
     prime:
@@ -13,7 +22,6 @@ parts:
       - templates
       - files
       - mod
-      - bundled_packages
       - requirements.txt
 
 bases:


### PR DESCRIPTION
Previous approach was to run make bundled-packages-update before charmcraft pack, but I think better solution is to leave it for charmcraft pack, so properly configure it in charmcraft.yaml

close: #7