### PR TITLE
add jammy and x64 labels for self-hosted runners

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,7 +31,7 @@ jobs:
         include:
           - juju-channel: "3.1/stable"
             command: "make functional"
-            runs-on: "['self-hosted', 'xlarge']"
+            runs-on: "['self-hosted', 'xlarge', 'jammy', 'x64']"
     with:
       command: ${{ matrix.command }}
       juju-channel: ${{ matrix.juju-channel }}


### PR DESCRIPTION
Adds the jammy and x64 labels for the self-hosted runner workflows to ensure the workflows don't break as we add more architectures and Ubuntu OS versions.