### PR TITLE
Set controller channel to 3.4 in CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,20 +23,11 @@ jobs:
       working-directory: .
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - juju-channel: "3.1/stable"
-            command: "make functional"
-            runs-on: "['self-hosted', 'xlarge']"
     with:
-      command: ${{ matrix.command }}
-      juju-channel: ${{ matrix.juju-channel }}
+      command: make functional
+      juju-channel: "3.4/stable"
       nested-containers: true
-      provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
-      tox-version: "<4"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,6 +10,10 @@ on:
       - "**.md"
       - "**.rst"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2
@@ -19,15 +23,21 @@ jobs:
         python-version: ["3.8", "3.10"]
     with:
       python-version: ${{ matrix.python-version }}
-      tox-version: "<4"
       working-directory: .
 
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - juju-channel: "3.4/stable"
+            command: "TEST_JUJU3=1 make functional"  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
     with:
-      command: make functional
-      juju-channel: "3.4/stable"
-      nested-containers: true
+      command: ${{ matrix.command }}
+      juju-channel: ${{ matrix.juju-channel }}
+      nested-containers: false
+      provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,10 @@ help:
 	@echo ""
 
 clean:
-	@echo "Cleaning files"
-	@git clean -ffXd -e '!.idea'
-	@cd mod/charm-helpers && git clean -ffXd -e '!.idea'
-	@echo "Cleaning existing build"
-	@rm -rf ${CHARM_BUILD_DIR}
-	@rm -rf ${CHARM_NAME}.charm
+	@echo "Cleaning charmcraft"
 	@charmcraft clean
+	@echo "Cleaning existing chamr files"
+	@rm -rf ${PROJECTPATH}/${CHARM_NAME}.charm
 
 submodules:
 	@echo "Cloning submodules"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,4 +16,3 @@ requires:
   general-info:
     interface: juju-info
     scope: container
-series: []

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/openstack-charmers/zaza.git@libjuju-3.1#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
 python-openstackclient
 python-hosts
 tenacity

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza
 python-openstackclient
 python-hosts
 tenacity

--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -29,10 +29,12 @@ applications:
     to:
       - "2"
   ud-ldap-server:
+    charm: "userdir-ldap"
     options:
       userdb-host: "userdb.internal"
       userdb-ip: "127.0.0.1"
   ud-ldap-client:
+    charm: "userdir-ldap"
     options:
       userdb-host: "userdb.internal"
 relations:

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ passenv =
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
   OS_*
+  TEST_*
 
 [testenv:lint]
 commands =
@@ -67,6 +68,5 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 
 [testenv:func]
 changedir = {toxinidir}/tests/functional
-setenv = TEST_JUJU3=1  # needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47
-commands = functest-run-suite {posargs}
+commands = functest-run-suite {posargs:--keep-faulty-model}
 deps = -r{toxinidir}/tests/functional/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -67,5 +67,6 @@ deps = -r{toxinidir}/tests/unit/requirements.txt
 
 [testenv:func]
 changedir = {toxinidir}/tests/functional
+setenv = TEST_JUJU3=1  # needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47
 commands = functest-run-suite {posargs}
 deps = -r{toxinidir}/tests/functional/requirements.txt


### PR DESCRIPTION
Add support for Juju 3.4 and drop bootstack-actions actions v3 with self-hosted runner, instead of that using official GitHub runner.

Simply sanitation of project and add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.