### PR TITLE
Add noble support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -31,6 +31,11 @@ bases:
       architectures: ["amd64", "arm64"]
     run-on:
       - name: ubuntu
+        channel: "24.04"
+        architectures:
+          - amd64
+          - arm64
+      - name: ubuntu
         channel: "22.04"
         architectures:
           - amd64


### PR DESCRIPTION
Note: we cannot add functional tests for noble, because this is a subordinate charm and we don't have any other principle charms that support noble yet.