### PR TITLE
Enforce 4096-bit RSA SSH key creation to match policy

### DIFF
--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -158,7 +158,7 @@ def create_ssh_keypair(id_file):
             "-t",
             "rsa",
             "-b",
-            "2048",
+            "4096",
             "-N",
             "",
             "-f",


### PR DESCRIPTION
Internal policy is that RSA keys should be at least 4096-bit.

The charm currently creates 2048-bit RSA keys, let's up that to match policy.